### PR TITLE
JingleJam total command

### DIFF
--- a/modules/Total/index.js
+++ b/modules/Total/index.js
@@ -7,18 +7,18 @@ const getBold = (string, discord) => {
 };
 
 module.exports = {
-  name: 'Jingle Jam Total',
+  name: 'Total',
   module(jaffamod) {
     jaffamod.registerCommand('total', (message, reply, discord) => {
       // Determine if it's Jingle Jam time
       //  (December + first 7 days of the new year to view the total raised)
       const d = new Date();
       if (d.getMonth() === 11 || (d.getMonth() === 0 && d.getDate() <= 7)) {
-        jaffamod.api.get('https://jinglejam.yogscast.com/api/total').catch(() => {
-          reply(`The total amount couldn't be determined currently. ${getEmote('yogP3', discord)} Please try again later.`);
-        }).then(data => {
+        jaffamod.api.get('https://jinglejam.yogscast.com/api/total').then(data => {
           const year = d.getMonth() === 11 ? d.getFullYear() : d.getFullYear() - 1; // Account for being in January
           reply(`We've currently raised a total of ${getBold(`$${data.formatted_total}`, discord)} for charity during Jingle Jam ${year} so far! Donate now at https://humble.com/yogs`);
+        }).catch(() => {
+          reply(`The total amount couldn't be determined currently. ${getEmote('yogP3', discord)} Please try again later.`);
         });
       } else {
         reply(`It's currently not Jingle Jam time. ${getEmote('yogP3', discord)} We look forward to seeing you in December to raise more money for charity once again!`);

--- a/modules/Total/index.js
+++ b/modules/Total/index.js
@@ -1,0 +1,28 @@
+const getEmote = (emote, discord) => {
+  return discord ? `:${emote}:` : emote;
+};
+
+const getBold = (string, discord) => {
+  return discord ? `**${string}**` : string;
+};
+
+module.exports = {
+  name: 'Total',
+  module(jaffamod) {
+    jaffamod.registerCommand('total', (message, reply, discord) => {
+      // Determine if it's JingleJam time
+      //  (December + first 7 days of the new year to view the total raised)
+      const d = new Date();
+      if (d.getMonth() === 11 || (d.getMonth() === 0 && d.getDate() <= 7)) {
+        jaffamod.api.get('https://jinglejam.yogscast.com/api/total').catch(() => {
+          reply(`The total amount couldn't be determined currently. ${getEmote('yogP3', discord)} Please try again later.`);
+        }).then(data => {
+          const year = d.getMonth() === 11 ? d.getFullYear() : d.getFullYear() - 1; // Account for being in January
+          reply(`We've currently raised a total of ${getBold(`$${data.formatted_total}`, discord)} for charity during JingleJam ${year} so far! Donate now at https://humble.com/yogs`);
+        });
+      } else {
+        reply(`It's currently not JingleJam time. ${getEmote('yogP3', discord)} We look forward to seeing you on Twitch in December to raise more money for charity once again!`);
+      }
+    });
+  }
+};

--- a/modules/Total/index.js
+++ b/modules/Total/index.js
@@ -7,10 +7,10 @@ const getBold = (string, discord) => {
 };
 
 module.exports = {
-  name: 'Total',
+  name: 'Jingle Jam Total',
   module(jaffamod) {
     jaffamod.registerCommand('total', (message, reply, discord) => {
-      // Determine if it's JingleJam time
+      // Determine if it's Jingle Jam time
       //  (December + first 7 days of the new year to view the total raised)
       const d = new Date();
       if (d.getMonth() === 11 || (d.getMonth() === 0 && d.getDate() <= 7)) {
@@ -18,10 +18,10 @@ module.exports = {
           reply(`The total amount couldn't be determined currently. ${getEmote('yogP3', discord)} Please try again later.`);
         }).then(data => {
           const year = d.getMonth() === 11 ? d.getFullYear() : d.getFullYear() - 1; // Account for being in January
-          reply(`We've currently raised a total of ${getBold(`$${data.formatted_total}`, discord)} for charity during JingleJam ${year} so far! Donate now at https://humble.com/yogs`);
+          reply(`We've currently raised a total of ${getBold(`$${data.formatted_total}`, discord)} for charity during Jingle Jam ${year} so far! Donate now at https://humble.com/yogs`);
         });
       } else {
-        reply(`It's currently not JingleJam time. ${getEmote('yogP3', discord)} We look forward to seeing you on Twitch in December to raise more money for charity once again!`);
+        reply(`It's currently not Jingle Jam time. ${getEmote('yogP3', discord)} We look forward to seeing you in December to raise more money for charity once again!`);
       }
     });
   }


### PR DESCRIPTION
This adds in a !total command for usage on both Discord & Twitch. It simply hits https://jinglejam.yogscast.com/api/total and returns the current total raised for the JingleJam.

I couldn't find anything on how to go about running this locally to test it works, so I've written this blind but it should work.