### PR TITLE
Use linebreaks for jinglecharities

### DIFF
--- a/modules/JingleCharities/index.js
+++ b/modules/JingleCharities/index.js
@@ -37,10 +37,10 @@ module.exports = {
 
         // Message for bundle being active
         if (jaffamod.utils.isJingleJam())
-          return reply(`${charities.join(', ')}. Get involved and donate at ${jaffamod.utils.getLink('https://jinglejam.tiltify.com', discord)}`);
+          return reply(`${charities.join(',\n')}.\nGet involved and donate at ${jaffamod.utils.getLink('https://jinglejam.tiltify.com', discord)}`);
 
         // Message for post-bundle
-        reply(`${charities.join(', ')}. Thank you for supporting some wonderful charities.`);
+        reply(`${charities.join(',\n')}.\nThank you for supporting some wonderful charities.`);
       })
         .catch(() => {
           // Web request failed or returned invalid data


### PR DESCRIPTION
Makes the command more readable in Discord, with a linebreak for each charity:

![image](https://user-images.githubusercontent.com/12371363/144515289-2f2da3ba-5b03-4cd2-bbe6-712480827162.png)

The linebreaks appear to be automatically discarded by Twitch and replaced with spaces, resulting in the same output as before:

![image](https://user-images.githubusercontent.com/12371363/144515336-68b273d2-e405-4575-a9fe-210f8ec2847d.png)
