### PR TITLE
Refactor to use in-repo Jingle Jam utils

### DIFF
--- a/modules/JingleCharities/index.js
+++ b/modules/JingleCharities/index.js
@@ -1,5 +1,5 @@
 const formatMoney = require('../../utils/formatMoney');
-const { getDates, msgNotJingleJam, msgNotBundleLaunched} = require('../../utils/jingleJam');
+const { getDates, msgNotJingleJam, msgNotBundleLaunched } = require('../../utils/jingleJam');
 
 // Shorten some charity names
 const charityMap = {

--- a/modules/Total/index.js
+++ b/modules/Total/index.js
@@ -1,17 +1,19 @@
 const formatMoney = require('../../utils/formatMoney');
+const { getDates, msgNotJingleJam, msgNotBundleLaunched } = require('../../utils/jingleJam');
 
 module.exports = {
   name: 'Total',
   module(jaffamod) {
     jaffamod.registerCommand('total', (message, reply, discord) => {
+      // Get key dates for JingleJam
+      const jingleDates = getDates();
+      const now = new Date();
+
       // Only run during JingleJam + first week of January
-      if (!jaffamod.utils.isJingleJamExt())
-        return reply(`It's not currently Jingle Jam time. ${jaffamod.utils.getEmote('yogP3', discord)} We look forward to seeing you in December to raise more money for charity once again!`);
+      if (now < jingleDates.start || now > jingleDates.extended) return reply(msgNotJingleJam(jaffamod, discord));
 
       // Bundle hasn't yet launched
-      const d = new Date();
-      if (d.getMonth() === 11 && d.getDate() === 1 && d.getHours() < 17)
-        return reply(`The Jingle Jam bundle hasn't launched yet! ${jaffamod.utils.getEmote('yogP3', discord)} Get ready to get the bundle and raise some money for charity once again!`);
+      if (now < jingleDates.launch) return reply(msgNotBundleLaunched(jaffamod, discord));
 
       // Get the total raised from the magical API
       jaffamod.api.get('https://jinglejam.yogscast.com/api/total').then(res => {
@@ -21,19 +23,16 @@ module.exports = {
           throw new Error(); // Force ourselves into the catch block
         }
 
-        // Get the year, accounting for being in January
-        const year = d.getMonth() === 11 ? d.getFullYear() : d.getFullYear() - 1;
-
         // Get the value raised
         const raised = formatMoney('£', res.data.total);
         const raisedUsd = formatMoney('$', res.data.total_usd);
 
         // Message for bundle being active
-        if (jaffamod.utils.isJingleJam())
-          return reply(`We've raised ${jaffamod.utils.getBold(raised, discord)} (${jaffamod.utils.getBold(raisedUsd, discord)}) for charity during Jingle Jam ${year} so far! Donate now at ${jaffamod.utils.getLink('https://jinglejam.tiltify.com', discord)}`);
+        if (now < jingleDates.end)
+          return reply(`We've raised ${jaffamod.utils.getBold(raised, discord)} (${jaffamod.utils.getBold(raisedUsd, discord)}) for charity during Jingle Jam ${jingleDates.year} so far! Donate now at ${jaffamod.utils.getLink('https://jinglejam.tiltify.com', discord)}`);
 
         // Message for post-bundle
-        reply(`We raised ${jaffamod.utils.getBold(raised, discord)} (${jaffamod.utils.getBold(raisedUsd, discord)}) for charity during Jingle Jam ${year}! Thank you for supporting some wonderful charities.`);
+        reply(`We raised ${jaffamod.utils.getBold(raised, discord)} (${jaffamod.utils.getBold(raisedUsd, discord)}) for charity during Jingle Jam ${jingleDates.year}! Thank you for supporting some wonderful charities.`);
       })
         .catch(() => {
           // Web request failed or returned invalid data

--- a/utils/jingleJam.js
+++ b/utils/jingleJam.js
@@ -1,0 +1,21 @@
+const getDates = (d = undefined) => {
+  const date = d === undefined ? new Date() : d;
+  const year = date.getMonth() === 11 ? date.getFullYear() : date.getFullYear() - 1;
+  return Object.freeze({
+    year,
+    start: new Date(year, 11, 1, 0, 0, 0, 0), // When the commands start working
+    launch: new Date(year, 11, 1, 17, 0, 0, 0), // When the commands start returning data (bundle available)
+    end: new Date(year, 11, 15, 0, 0, 0, 0), // When the commands switch to past tense (bundle ended)
+    extended: new Date(year + 1, 0, 8, 0, 0, 0, 0), // When the commands stop working
+  });
+};
+
+const msgNotJingleJam = (jaffamod, discord) => `It's not currently Jingle Jam time. ${jaffamod.utils.getEmote('yogP3', discord)} We look forward to seeing you in December to raise more money for charity once again!`;
+
+const msgNotBundleLaunched = (jaffamod, discord) => `The Jingle Jam bundle hasn't launched yet! ${jaffamod.utils.getEmote('yogP3', discord)} Get ready to get the bundle and raise some money for charity once again!`;
+
+module.exports = Object.freeze({
+  getDates,
+  msgNotJingleJam,
+  msgNotBundleLaunched,
+});

--- a/utils/jingleJam.js
+++ b/utils/jingleJam.js
@@ -6,7 +6,7 @@ const getDates = (d = undefined) => {
     start: new Date(year, 11, 1, 0, 0, 0, 0), // When the commands start working
     launch: new Date(year, 11, 1, 17, 0, 0, 0), // When the commands start returning data (bundle available)
     end: new Date(year, 11, 15, 0, 0, 0, 0), // When the commands switch to past tense (bundle ended)
-    extended: new Date(year + 1, 0, 8, 0, 0, 0, 0), // When the commands stop working
+    extended: new Date(year + 1, 0, 8, 0, 0, 0, 0) // When the commands stop working
   });
 };
 
@@ -17,5 +17,5 @@ const msgNotBundleLaunched = (jaffamod, discord) => `The Jingle Jam bundle hasn'
 module.exports = Object.freeze({
   getDates,
   msgNotJingleJam,
-  msgNotBundleLaunched,
+  msgNotBundleLaunched
 });


### PR DESCRIPTION
Switches away from using the Jingle Jam utils in the core bot to dedicated utils directly in the repo. As these utils are only used by these commands, it feels cleaner to have them in this repo rather than part of the core bot.