### PR TITLE
Reintroduce linebreak in jinglecharities from merge

### DIFF
--- a/modules/JingleCharities/index.js
+++ b/modules/JingleCharities/index.js
@@ -39,7 +39,7 @@ module.exports = {
 
         // Message for bundle being active
         if (now < jingleDates.end)
-          return reply(`${charities.join(', ')}. Get involved and donate at ${jaffamod.utils.getLink('https://jinglejam.tiltify.com', discord)}`);
+          return reply(`${charities.join(',\n')}.\nGet involved and donate at ${jaffamod.utils.getLink('https://jinglejam.tiltify.com', discord)}`);
 
         // Message for post-bundle
         reply(`${charities.join(',\n')}.\nThank you for supporting some wonderful charities.`);


### PR DESCRIPTION
#14 / #13 had a bad merge that resulted in the linebreaks being lost for one variant of the message.