### PR TITLE
Jingle Jam 2022

### DIFF
--- a/modules/JingleCharities/index.js
+++ b/modules/JingleCharities/index.js
@@ -3,11 +3,8 @@ const { getDates, msgNotJingleJam, msgNotBundleLaunched } = require('../../utils
 
 // Shorten some charity names
 const charityMap = {
-  'Call of Duty Endowment - UK': 'CODE',
-  'Cancer Research UK': 'CRUK',
-  'The Mental Health Foundation': 'Mental Health Foundation',
-  'War Child UK': 'War Child',
-  'Whale and Dolphin Conservation (WDC)': 'WDC'
+  'Campaign Against Living Miserably (CALM)': 'CALM',
+  'Whale and Dolphin Conservations': 'WDC'
 };
 
 module.exports = {

--- a/modules/JingleCharities/index.js
+++ b/modules/JingleCharities/index.js
@@ -25,16 +25,16 @@ module.exports = {
       if (now < jingleDates.launch) return reply(msgNotBundleLaunched(jaffamod, discord));
 
       // Get the campaign data from the Tiltify API
-      jaffamod.api.get('https://api.tiltify.com/custom/yoggscast-2021').then(res => {
+      jaffamod.api.get('https://dashboard.jinglejam.co.uk/api/tiltify').then(res => {
         // Validate the response from API
-        if (!res || !res.data.data || !res.data.data.campaigns || !Array.isArray(res.data.data.campaigns)) {
+        if (!res || !res.data || !res.data.campaigns || !Array.isArray(res.data.campaigns)) {
           console.error(`Couldn't run jinglecharities command, got bad data`, res.data);
           throw new Error(); // Force ourselves into the catch block
         }
 
         // Get totals for each charity
-        const charities = res.data.data.campaigns
-          .map(campaign => `${charityMap[campaign.cause.name] || campaign.cause.name}: ${formatMoney('£', Number(campaign.amount_raised.value))}`)
+        const charities = res.data.campaigns
+          .map(campaign => `${charityMap[campaign.name] || campaign.name}: ${formatMoney('£', campaign.total.pounds)}`)
           .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
 
         // Message for bundle being active

--- a/modules/JingleCharities/index.js
+++ b/modules/JingleCharities/index.js
@@ -1,10 +1,11 @@
 const formatMoney = require('../../utils/formatMoney');
 const { getDates, msgNotJingleJam, msgNotBundleLaunched } = require('../../utils/jingleJam');
+const paginate = require('../../utils/paginate');
 
-// Shorten some charity names
-const charityMap = {
-  'Campaign Against Living Miserably (CALM)': 'CALM',
-  'Whale and Dolphin Conservations': 'WDC'
+const replyPaginated = async (message, reply) => {
+  for (const page of paginate(message)) {
+    await reply(page);
+  }
 };
 
 module.exports = {
@@ -22,7 +23,7 @@ module.exports = {
       if (now < jingleDates.launch) return reply(msgNotBundleLaunched(jaffamod, discord));
 
       // Get the campaign data from the Tiltify API
-      jaffamod.api.get('https://dashboard.jinglejam.co.uk/api/tiltify').then(res => {
+      return jaffamod.api.get('https://dashboard.jinglejam.co.uk/api/tiltify').then(res => {
         // Validate the response from API
         if (!res || !res.data || !res.data.campaigns || !Array.isArray(res.data.campaigns)) {
           throw new Error(`Got bad data: ${JSON.stringify(res.data)}`); // Force ourselves into the catch block
@@ -30,21 +31,21 @@ module.exports = {
 
         // Get totals for each charity
         const charities = res.data.campaigns
-          .map(campaign => `${charityMap[campaign.name] || campaign.name}: ${formatMoney('£', campaign.total.pounds)}`)
+          .map(campaign => `${campaign.name}: ${formatMoney('£', campaign.total.pounds)}`)
           .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
 
         // Message for bundle being active
         if (now < jingleDates.end)
-          return reply(`${charities.join(',\n')}.\nGet involved and donate at ${jaffamod.utils.getLink('https://jinglejam.tiltify.com', discord)}`);
+          return replyPaginated(`${charities.join(',\n')}.\nGet involved and donate at ${jaffamod.utils.getLink('https://jinglejam.tiltify.com', discord)}`, reply);
 
         // Message for post-bundle
-        reply(`${charities.join(',\n')}.\nThank you for supporting some wonderful charities.`);
+        return replyPaginated(`${charities.join(',\n')}.\nThank you for supporting some wonderful charities.`, reply);
       })
         .catch(e => {
           console.error(`Couldn't run jinglecharities command`, e);
 
           // Web request failed or returned invalid data
-          reply(`Jingle Jam charity data couldn't be determined. ${jaffamod.utils.getEmote('yogP3', discord)} Please try again later.`);
+          return reply(`Jingle Jam charity data couldn't be determined. ${jaffamod.utils.getEmote('yogP3', discord)} Please try again later.`);
         });
     });
   }

--- a/modules/JingleCharities/index.js
+++ b/modules/JingleCharities/index.js
@@ -25,8 +25,7 @@ module.exports = {
       jaffamod.api.get('https://dashboard.jinglejam.co.uk/api/tiltify').then(res => {
         // Validate the response from API
         if (!res || !res.data || !res.data.campaigns || !Array.isArray(res.data.campaigns)) {
-          console.error(`Couldn't run jinglecharities command, got bad data`, res.data);
-          throw new Error(); // Force ourselves into the catch block
+          throw new Error(`Got bad data: ${JSON.stringify(res.data)}`); // Force ourselves into the catch block
         }
 
         // Get totals for each charity
@@ -41,7 +40,9 @@ module.exports = {
         // Message for post-bundle
         reply(`${charities.join(',\n')}.\nThank you for supporting some wonderful charities.`);
       })
-        .catch(() => {
+        .catch(e => {
+          console.error(`Couldn't run jinglecharities command`, e);
+
           // Web request failed or returned invalid data
           reply(`Jingle Jam charity data couldn't be determined. ${jaffamod.utils.getEmote('yogP3', discord)} Please try again later.`);
         });

--- a/modules/JingleStats/index.js
+++ b/modules/JingleStats/index.js
@@ -17,9 +17,13 @@ module.exports = {
       if (now < jingleDates.launch) return reply(msgNotBundleLaunched(jaffamod, discord));
 
       // Get the total raised from the magical API
-      jaffamod.api.get('https://jinglejam.yogscast.com/api/total').then(res => {
+      jaffamod.api.get('https://dashboard.jinglejam.co.uk/api/tiltify').then(res => {
         // Validate the response from API
-        if (!res || !res.data || !res.data.total || !res.data.total_usd || !res.data.donations_with_reward) {
+        if (!res || !res.data
+          || !res.data.total || !res.data.total.pounds || !res.data.total.dollars
+          || !res.data.average || !res.data.average.pounds || !res.data.average.dollars
+          || !res.data.bundles || !res.data.bundles.sold
+          || !res.data.entire || !res.data.entire.amount || !res.data.entire.amount.pounds || !res.data.entire.amount.dollars) {
           console.error(`Couldn't run jinglestats command, got bad data`, res.data);
           throw new Error(); // Force ourselves into the catch block
         }
@@ -30,28 +34,40 @@ module.exports = {
         const daysSinceLaunch = Math.max(hoursSinceLaunch / 24, 1);
 
         // Stats!
-        const total = jaffamod.utils.getBold(formatMoney('£', res.data.total), discord);
-        const totalUsd = jaffamod.utils.getBold(formatMoney('$', res.data.total_usd), discord);
-        const bundles = jaffamod.utils.getBold(res.data.donations_with_reward.toLocaleString(), discord);
-        const perBundle = jaffamod.utils.getBold(formatMoney('£', res.data.total / res.data.donations_with_reward), discord);
-        const perHour = jaffamod.utils.getBold(formatMoney('£', res.data.total / hoursSinceLaunch), discord);
-        const bundlesPerHour = jaffamod.utils.getBold(Math.round(res.data.donations_with_reward / hoursSinceLaunch).toLocaleString(), discord);
-        const perDay = jaffamod.utils.getBold(formatMoney('£', res.data.total / daysSinceLaunch), discord);
-        const bundlesPerDay = jaffamod.utils.getBold(Math.round(res.data.donations_with_reward / daysSinceLaunch).toLocaleString(), discord);
+        const total = jaffamod.utils.getBold(formatMoney('£', res.data.total.pounds), discord);
+        const totalUsd = jaffamod.utils.getBold(formatMoney('$', res.data.total.dollars), discord);
+        const totalYogscast = jaffamod.utils.getBold(formatMoney('£', res.data.raised.pounds), discord);
+        const totalFundraisers = jaffamod.utils.getBold(formatMoney('£', res.data.fundraisers.pounds), discord);
+
+        const average = jaffamod.utils.getBold(formatMoney('£', res.data.average.pounds), discord);
+        const averageUsd = jaffamod.utils.getBold(formatMoney('$', res.data.average.dollars), discord);
+
+        const bundles = jaffamod.utils.getBold(res.data.bundles.sold.toLocaleString(), discord);
+        const perBundle = jaffamod.utils.getBold(formatMoney('£', res.data.total.pounds / res.data.bundles.sold), discord);
+
+        const perHour = jaffamod.utils.getBold(formatMoney('£', res.data.total.pounds / hoursSinceLaunch), discord);
+        const bundlesPerHour = jaffamod.utils.getBold(Math.round(res.data.bundles.sold / hoursSinceLaunch).toLocaleString(), discord);
+        const perDay = jaffamod.utils.getBold(formatMoney('£', res.data.total.pounds / daysSinceLaunch), discord);
+        const bundlesPerDay = jaffamod.utils.getBold(Math.round(res.data.bundles.sold / daysSinceLaunch).toLocaleString(), discord);
+
+        const entire = jaffamod.utils.getBold(formatMoney('£', res.data.entire.amount.pounds), discord);
+        const entireUsd = jaffamod.utils.getBold(formatMoney('$', res.data.entire.amount.dollars), discord);
 
         // Message for bundle being active
         if (now < jingleDates.end)
-          return reply(`We've raised a total of ${total} (${totalUsd}) for charity, with ${bundles} bundles claimed, during Jingle Jam ${jingleDates.year} so far!`
-            + ` That works out to an average of ${perBundle} donated to awesome charities per bundle claimed! ${shookEmote(jaffamod, discord)}`
-            + ` Per hour, that's approximately ${perHour} donated and ${bundlesPerHour} bundles claimed.`
-            + ` Or, instead, that's roughly ${bundlesPerDay} bundles claimed and ${perDay} donated per day on average.`
+          return reply(`We've raised a total of ${total} (${totalUsd}) for charity (${totalYogscast} by the Yogscast, ${totalFundraisers} from fundraisers), with ${bundles} collections sold, during Jingle Jam ${jingleDates.year} so far!`
+            + ` That works out to an average of ${average} (${averageUsd}) per donation, and ${perBundle} donated to awesome charities per collection claimed! ${shookEmote(jaffamod, discord)}`
+            + ` Per hour, that's approximately ${perHour} donated and ${bundlesPerHour} collections claimed.`
+            + ` Or, instead, that's roughly ${bundlesPerDay} collections claimed and ${perDay} donated per day on average.`
+            + ` Over all the years of Jingle Jam, a total of ${entire} (${entireUsd}) has been raised for charity!`
             + ` Get involved by donating now at ${jaffamod.utils.getLink('https://jinglejam.tiltify.com', discord)}`);
 
         // Message for post-bundle
-        reply(`We raised a total of ${total} (${totalUsd}) for charity, with ${bundles} bundles claimed, during Jingle Jam ${jingleDates.year}!`
-          + ` That worked out to ${perBundle} donated to awesome charities per bundle claimed on average! ${shookEmote(jaffamod, discord)}`
-          + ` Hourly, ${bundlesPerHour} bundles were claimed and ${perHour} was donated to charity. `
-          + ` Or, per day during the Jingle Jam, ${bundlesPerDay} bundles were claimed and ${perDay} donated.`
+        reply(`We raised a total of ${total} (${totalUsd}) for charity (${totalYogscast} by the Yogscast, ${totalFundraisers} from fundraisers), with ${bundles} collections claimed, during Jingle Jam ${jingleDates.year}!`
+          + ` That worked out to ${average} (${averageUsd}) per donation, and ${perBundle} donated to awesome charities per collection claimed on average! ${shookEmote(jaffamod, discord)}`
+          + ` Hourly, ${bundlesPerHour} collections were claimed and ${perHour} was donated to charity.`
+          + ` Or, per day during the Jingle Jam, ${bundlesPerDay} collections were claimed and ${perDay} donated.`
+          + ` Over all the years of Jingle Jam, a total of ${entire} (${entireUsd}) has been raised for charity!`
           + ` Thank you for supporting some wonderful charities.`);
       })
         .catch(() => {

--- a/modules/JingleStats/index.js
+++ b/modules/JingleStats/index.js
@@ -1,6 +1,13 @@
 const formatMoney = require('../../utils/formatMoney');
 const shookEmote = require('../../utils/shookEmote');
 const { getDates, msgNotJingleJam, msgNotBundleLaunched } = require('../../utils/jingleJam');
+const paginate = require('../../utils/paginate');
+
+const replyPaginated = async (message, reply) => {
+  for (const page of paginate(message)) {
+    await reply(page);
+  }
+};
 
 module.exports = {
   name: 'JingleStats',
@@ -17,7 +24,7 @@ module.exports = {
       if (now < jingleDates.launch) return reply(msgNotBundleLaunched(jaffamod, discord));
 
       // Get the total raised from the magical API
-      jaffamod.api.get('https://dashboard.jinglejam.co.uk/api/tiltify').then(res => {
+      return jaffamod.api.get('https://dashboard.jinglejam.co.uk/api/tiltify').then(res => {
         // Validate the response from API
         if (!res || !res.data
           || !res.data.total || !res.data.total.pounds || !res.data.total.dollars
@@ -54,26 +61,26 @@ module.exports = {
 
         // Message for bundle being active
         if (now < jingleDates.end)
-          return reply(`We've raised a total of ${total} (${totalUsd}) for charity (${totalYogscast} by the Yogscast, ${totalFundraisers} from fundraisers), with ${bundles} collections sold, during Jingle Jam ${jingleDates.year} so far!`
+          return replyPaginated(`We've raised a total of ${total} (${totalUsd}) for charity (${totalYogscast} by the Yogscast, ${totalFundraisers} from fundraisers), with ${bundles} collections sold, during Jingle Jam ${jingleDates.year} so far!`
             + ` That works out to an average of ${average} (${averageUsd}) per donation, and ${perBundle} donated to awesome charities per collection claimed! ${shookEmote(jaffamod, discord)}`
             + ` Per hour, that's approximately ${perHour} donated and ${bundlesPerHour} collections claimed.`
             + ` Or, instead, that's roughly ${bundlesPerDay} collections claimed and ${perDay} donated per day on average.`
             + ` Over all the years of Jingle Jam, a total of ${entire} (${entireUsd}) has been raised for charity!`
-            + ` Get involved by donating now at ${jaffamod.utils.getLink('https://jinglejam.tiltify.com', discord)}`);
+            + ` Get involved by donating now at ${jaffamod.utils.getLink('https://jinglejam.tiltify.com', discord)}`, reply);
 
         // Message for post-bundle
-        reply(`We raised a total of ${total} (${totalUsd}) for charity (${totalYogscast} by the Yogscast, ${totalFundraisers} from fundraisers), with ${bundles} collections claimed, during Jingle Jam ${jingleDates.year}!`
+        return replyPaginated(`We raised a total of ${total} (${totalUsd}) for charity (${totalYogscast} by the Yogscast, ${totalFundraisers} from fundraisers), with ${bundles} collections claimed, during Jingle Jam ${jingleDates.year}!`
           + ` That worked out to ${average} (${averageUsd}) per donation, and ${perBundle} donated to awesome charities per collection claimed on average! ${shookEmote(jaffamod, discord)}`
           + ` Hourly, ${bundlesPerHour} collections were claimed and ${perHour} was donated to charity.`
           + ` Or, per day during the Jingle Jam, ${bundlesPerDay} collections were claimed and ${perDay} donated.`
           + ` Over all the years of Jingle Jam, a total of ${entire} (${entireUsd}) has been raised for charity!`
-          + ` Thank you for supporting some wonderful charities.`);
+          + ` Thank you for supporting some wonderful charities.`, reply);
       })
         .catch(e => {
           console.error(`Couldn't run jinglestats command`, e);
 
           // Web request failed or returned invalid data
-          reply(`Jingle Jam stats couldn't be determined. ${jaffamod.utils.getEmote('yogP3', discord)} Please try again later.`);
+          return reply(`Jingle Jam stats couldn't be determined. ${jaffamod.utils.getEmote('yogP3', discord)} Please try again later.`);
         });
     });
   }

--- a/modules/JingleStats/index.js
+++ b/modules/JingleStats/index.js
@@ -24,8 +24,7 @@ module.exports = {
           || !res.data.average || !res.data.average.pounds || !res.data.average.dollars
           || !res.data.bundles || !res.data.bundles.sold
           || !res.data.entire || !res.data.entire.amount || !res.data.entire.amount.pounds || !res.data.entire.amount.dollars) {
-          console.error(`Couldn't run jinglestats command, got bad data`, res.data);
-          throw new Error(); // Force ourselves into the catch block
+          throw new Error(`Got bad data: ${JSON.stringify(res.data)}`); // Force ourselves into the catch block
         }
 
         // Time since launch
@@ -70,7 +69,9 @@ module.exports = {
           + ` Over all the years of Jingle Jam, a total of ${entire} (${entireUsd}) has been raised for charity!`
           + ` Thank you for supporting some wonderful charities.`);
       })
-        .catch(() => {
+        .catch(e => {
+          console.error(`Couldn't run jinglestats command`, e);
+
           // Web request failed or returned invalid data
           reply(`Jingle Jam stats couldn't be determined. ${jaffamod.utils.getEmote('yogP3', discord)} Please try again later.`);
         });

--- a/modules/Total/index.js
+++ b/modules/Total/index.js
@@ -16,16 +16,17 @@ module.exports = {
       if (now < jingleDates.launch) return reply(msgNotBundleLaunched(jaffamod, discord));
 
       // Get the total raised from the magical API
-      jaffamod.api.get('https://jinglejam.yogscast.com/api/total').then(res => {
+      jaffamod.api.get('https://dashboard.jinglejam.co.uk/api/tiltify').then(res => {
         // Validate the response from API
-        if (!res || !res.data || !res.data.total || !res.data.total_usd) {
+        if (!res || !res.data
+          || !res.data.total || !res.data.total.pounds || !res.data.total.dollars) {
           console.error(`Couldn't run total command, got bad data`, res.data);
           throw new Error(); // Force ourselves into the catch block
         }
 
         // Get the value raised
-        const raised = formatMoney('£', res.data.total);
-        const raisedUsd = formatMoney('$', res.data.total_usd);
+        const raised = formatMoney('£', res.data.total.pounds);
+        const raisedUsd = formatMoney('$', res.data.total.dollars);
 
         // Message for bundle being active
         if (now < jingleDates.end)

--- a/modules/Total/index.js
+++ b/modules/Total/index.js
@@ -20,8 +20,7 @@ module.exports = {
         // Validate the response from API
         if (!res || !res.data
           || !res.data.total || !res.data.total.pounds || !res.data.total.dollars) {
-          console.error(`Couldn't run total command, got bad data`, res.data);
-          throw new Error(); // Force ourselves into the catch block
+          throw new Error(`Got bad data: ${JSON.stringify(res.data)}`); // Force ourselves into the catch block
         }
 
         // Get the value raised
@@ -35,7 +34,9 @@ module.exports = {
         // Message for post-bundle
         reply(`We raised ${jaffamod.utils.getBold(raised, discord)} (${jaffamod.utils.getBold(raisedUsd, discord)}) for charity during Jingle Jam ${jingleDates.year}! Thank you for supporting some wonderful charities.`);
       })
-        .catch(() => {
+        .catch(e => {
+          console.error(`Couldn't run total command`, e);
+
           // Web request failed or returned invalid data
           reply(`The total amount couldn't be determined. ${jaffamod.utils.getEmote('yogP3', discord)} Please try again later.`);
         });

--- a/utils/paginate.js
+++ b/utils/paginate.js
@@ -1,0 +1,28 @@
+module.exports = (message, sep = /[.,!] /, max = 500) => {
+  // Ensure separator is a global RegExp
+  const sepRe = new RegExp(sep instanceof RegExp ? sep.source : sep, (sep instanceof RegExp ? sep.flags : '') + 'g');
+
+  const messages = [message];
+  while (messages[messages.length - 1].length > max) {
+    // Get the message that is too long
+    const last = messages[messages.length - 1];
+
+    // Limit the length of the message to the max
+    const limited = last.substring(0, max);
+
+    // Match on the separator
+    const match = [ ...limited.matchAll(sepRe) ].slice(-1)[0];
+    if (match) {
+      // If there is a match, split on the separator
+      messages[messages.length - 1] = last.substring(0, match.index + match[0].length);
+      messages.push(last.substring(match.index + match[0].length));
+      continue;
+    }
+
+    // If there is no match, split on the max
+    messages[messages.length - 1] = last.substring(0, max - 3) + '...';
+    messages.push('...' + last.substring(max - 3));
+  }
+
+  return messages;
+};

--- a/utils/paginate.js
+++ b/utils/paginate.js
@@ -1,4 +1,4 @@
-module.exports = (message, sep = /[.,!] /, max = 500) => {
+module.exports = (message, sep = /[.,!]\s/, max = 500) => {
   // Ensure separator is a global RegExp
   const sepRe = new RegExp(sep instanceof RegExp ? sep.source : sep, (sep instanceof RegExp ? sep.flags : '') + 'g');
 


### PR DESCRIPTION
Switches all the JJ-related commands to using the new [tracker](https://www.jinglejam.co.uk/tracker) [API](https://dashboard.jinglejam.co.uk/api/tiltify).

Adds a quick pagination util as the stats message (and probably the charities message down the road) are too long for a single Twitch message.

![image](https://user-images.githubusercontent.com/12371363/205127005-c85c34ca-1e0e-494c-b4d2-79315861f59b.png)

![image](https://user-images.githubusercontent.com/12371363/205127031-36655294-2be1-48e0-8973-b5dc4b9c94e5.png)

![image](https://user-images.githubusercontent.com/12371363/205127053-027852b0-019e-4b81-bc92-d50f7d2a6123.png)
